### PR TITLE
Fixing missing simulation links

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -221,14 +221,14 @@ def inject_template_data(resp):
 
     try:
         response = s3.get_object(Bucket='blackfynn-discover-use1',
-                                 Key='{}/{}/packages/template.json'.format(id, version),
+                                 Key='{}/{}/files/template.json'.format(id, version),
                                  RequestPayer='requester')
     except ClientError as e:
-        # If the file is not under folder 'packages', check under folder 'files'
-        logging.warning('Required file template.json was not found under /packages folder, trying under /files...')
+        # If the file is not under folder 'files', check under folder 'packages'
+        logging.warning('Required file template.json was not found under /files folder, trying under /packages...')
         try:
             response = s3.get_object(Bucket='blackfynn-discover-use1',
-                                     Key='{}/{}/files/template.json'.format(id, version),
+                                     Key='{}/{}/packages/template.json'.format(id, version),
                                      RequestPayer='requester')
         except ClientError as e2:
             logging.error(e2)

--- a/api/api.py
+++ b/api/api.py
@@ -224,8 +224,15 @@ def inject_template_data(resp):
                                  Key='{}/{}/packages/template.json'.format(id, version),
                                  RequestPayer='requester')
     except ClientError as e:
-        logging.error(e)
-        return
+        # If the file is not under folder 'packages', check under folder 'files'
+        logging.warning('Required file template.json was not found under /packages folder, trying under /files...')
+        try:
+            response = s3.get_object(Bucket='blackfynn-discover-use1',
+                                     Key='{}/{}/files/template.json'.format(id, version),
+                                     RequestPayer='requester')
+        except ClientError as e2:
+            logging.error(e2)
+            return
 
     template = response['Body'].read()
 


### PR DESCRIPTION
# Description
Proposal for fixing a regression in which newly published datasets were missing the simulation links in the portal.
The issue was caused because now the name of the folder under which the files are places is called ``files`` (before it was ``packages``).
The fix simply checks under /packages if it doesn't find the file in /files, to support older publications.

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

The links are back on.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
